### PR TITLE
Remove duplicate class name in definition

### DIFF
--- a/src/entities/entity100.cpp
+++ b/src/entities/entity100.cpp
@@ -217,7 +217,7 @@ bool IGES_ENTITY_100::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_100::IGES_ENTITY_100::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_100::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     return IGES_ENTITY::AddReference( aParentEntity, isDuplicate );
 }

--- a/src/entities/entity102.cpp
+++ b/src/entities/entity102.cpp
@@ -449,7 +449,7 @@ bool IGES_ENTITY_102::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_102::IGES_ENTITY_102::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_102::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     if( !aParentEntity )
     {

--- a/src/entities/entity110.cpp
+++ b/src/entities/entity110.cpp
@@ -169,7 +169,7 @@ bool IGES_ENTITY_110::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_110::IGES_ENTITY_110::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_110::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     return IGES_ENTITY::AddReference( aParentEntity, isDuplicate );
 }

--- a/src/entities/entity122.cpp
+++ b/src/entities/entity122.cpp
@@ -236,7 +236,7 @@ bool IGES_ENTITY_122::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_122::IGES_ENTITY_122::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_122::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     if( !aParentEntity )
     {

--- a/src/entities/entity124.cpp
+++ b/src/entities/entity124.cpp
@@ -259,7 +259,7 @@ bool IGES_ENTITY_124::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_124::IGES_ENTITY_124::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_124::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     return IGES_ENTITY::AddReference( aParentEntity, isDuplicate );
 }

--- a/src/entities/entity154.cpp
+++ b/src/entities/entity154.cpp
@@ -182,7 +182,7 @@ bool IGES_ENTITY_154::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_154::IGES_ENTITY_154::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_154::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     return IGES_ENTITY::AddReference( aParentEntity, isDuplicate );
 }

--- a/src/entities/entity164.cpp
+++ b/src/entities/entity164.cpp
@@ -246,7 +246,7 @@ bool IGES_ENTITY_164::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_164::IGES_ENTITY_164::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_164::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     if( !aParentEntity )
     {

--- a/src/entities/entity180.cpp
+++ b/src/entities/entity180.cpp
@@ -334,7 +334,7 @@ bool IGES_ENTITY_180::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_180::IGES_ENTITY_180::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
+bool IGES_ENTITY_180::AddReference( IGES_ENTITY* aParentEntity, bool& isDuplicate )
 {
     return IGES_ENTITY::AddReference( aParentEntity, isDuplicate );
 }

--- a/src/entities/entity408.cpp
+++ b/src/entities/entity408.cpp
@@ -244,7 +244,7 @@ bool IGES_ENTITY_408::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_408::IGES_ENTITY_408::AddReference( IGES_ENTITY* aParentEntity,
+bool IGES_ENTITY_408::AddReference( IGES_ENTITY* aParentEntity,
                                                      bool& isDuplicate )
 {
     if( !aParentEntity )

--- a/src/entities/entity_template.cpp
+++ b/src/entities/entity_template.cpp
@@ -74,7 +74,7 @@ bool IGES_ENTITY_TEMP::IsOrphaned( void )
 }
 
 
-bool IGES_ENTITY_TEMP::IGES_ENTITY_TEMP::AddReference( IGES_ENTITY* aParentEntity,
+bool IGES_ENTITY_TEMP::AddReference( IGES_ENTITY* aParentEntity,
                                                        bool& isDuplicate )
 {
     // XXX - TO BE IMPLEMENTED


### PR DESCRIPTION
While technically legal, MSVC chokes on it.