### PR TITLE
Fix linking error on windows target, fixes #11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,7 +130,10 @@ if( SISL_NEEDS_BUILD )
     add_dependencies( iges sisl_submod )
 endif()
 
-target_link_libraries( iges "${SISL_LIBRARIES}" "${Boost_LIBRARIES}" )
+# Note that putting quotes around the variables here will make linking
+# fail on windows target bulds, both GCC cross compilation and MSVC
+# native.
+target_link_libraries( iges ${SISL_LIBRARIES} ${Boost_LIBRARIES} )
 
 add_executable( readtest
     "${LIBIGES_SOURCE_DIR}/tests/test_read.cpp"

--- a/src/idf/CMakeLists.txt
+++ b/src/idf/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library( idf3 STATIC
     idf_parser.cpp )
 
 add_executable( idf2igs idf2igs.cpp )
-target_link_libraries( idf2igs iges idf3 "${Boost_LIBRARIES}" )
+target_link_libraries( idf2igs iges idf3 ${Boost_LIBRARIES} )


### PR DESCRIPTION
Note that putting quotes around the variables here will make linking
fail on windows target bulds, both GCC cross compilation and MSVC
native.