### PR TITLE
Completes Start and End Point Identification for Type 126 Entities

### DIFF
--- a/src/entities/entity126.cpp
+++ b/src/entities/entity126.cpp
@@ -926,9 +926,22 @@ bool IGES_ENTITY_126::GetEndPoint( MCAD_POINT& pt, bool xform )
     pt.y = vals[1];
     pt.z = vals[2];
 #else
-    pt.x = coeffs[nCoeffs-2];
-    pt.y = coeffs[nCoeffs-1];
-    pt.z = coeffs[nCoeffs];
+    if ( PROP3 == 0 ) // rational
+    {
+        int nPnts = nCoeffs * 4;
+
+        pt.x = coeffs[nPnts - 4];
+        pt.y = coeffs[nPnts - 3];
+        pt.z = coeffs[nPnts - 2];
+    }
+    else
+    {
+        int nPnts = nCoeffs * 3;
+
+        pt.x = coeffs[nPnts - 3];
+        pt.y = coeffs[nPnts - 2];
+        pt.z = coeffs[nPnts - 1];
+    }
 #endif
 
     if( xform && pTransform )

--- a/src/entities/entity126.cpp
+++ b/src/entities/entity126.cpp
@@ -868,6 +868,10 @@ bool IGES_ENTITY_126::GetStartPoint( MCAD_POINT& pt, bool xform )
     pt.x = vals[0];
     pt.y = vals[1];
     pt.z = vals[2];
+#else
+    pt.x = coeffs[0];
+    pt.y = coeffs[1];
+    pt.z = coeffs[2];
 #endif
 
     if( xform && pTransform )
@@ -921,6 +925,10 @@ bool IGES_ENTITY_126::GetEndPoint( MCAD_POINT& pt, bool xform )
     pt.x = vals[0];
     pt.y = vals[1];
     pt.z = vals[2];
+#else
+    pt.x = coeffs[nCoeffs-2];
+    pt.y = coeffs[nCoeffs-1];
+    pt.z = coeffs[nCoeffs];
 #endif
 
     if( xform && pTransform )


### PR DESCRIPTION
If "USE_SISL" is false, IGES_ENTITY_126::GetStartPoint and IGES_ENTITY_126::GetEndPoint do not identify the start and end points of the NURBS curve. "pt" remains set to its initialization value unless a transformation matrix is defined for the NURBS curve. When calling IGES_ENTITY_102::AddSegment, any segment after the first two fail to be added because IGES_ENTITY_102::IsClosed incorrectly returns true. 