### PR TITLE
Libraries should never write to stdout, write to stderr instead

### DIFF
--- a/src/entities/entityNULL.cpp
+++ b/src/entities/entityNULL.cpp
@@ -245,8 +245,8 @@ bool IGES_ENTITY_NULL::readPD(std::ifstream &aFile, int &aSequenceVar)
     IGES_RECORD rec;
 
 #ifdef DEBUG
-    cout << "[INFO] Entity(NULL/" << trueEntity;
-    cout << ") Parameter Data Record for entity at DE " << sequenceNumber << "\n";
+    cerr << "[INFO] Entity(NULL/" << trueEntity;
+    cerr << ") Parameter Data Record for entity at DE " << sequenceNumber << "\n";
 #endif
 
     for(int i = 0; i < paramLineCount; ++i)
@@ -261,7 +261,7 @@ bool IGES_ENTITY_NULL::readPD(std::ifstream &aFile, int &aSequenceVar)
         }
 
 #ifdef DEBUG
-        cout << "    " << rec.data << "\n";
+        cerr << "    " << rec.data << "\n";
 #endif
 
         if( rec.section_type != 'P' )
@@ -285,7 +285,7 @@ bool IGES_ENTITY_NULL::readPD(std::ifstream &aFile, int &aSequenceVar)
     }
 
 #ifdef DEBUG
-    cout << "-----\n";
+    cerr << "-----\n";
 #endif
 
     aSequenceVar += paramLineCount;

--- a/src/entities/iges_entity.cpp
+++ b/src/entities/iges_entity.cpp
@@ -1460,8 +1460,8 @@ bool IGES_ENTITY::readPD(std::ifstream &aFile, int &aSequenceVar)
     char rd = parent->globalData.rdelim;
 
 #ifdef DEBUG
-    cout << "[INFO] Entity(" << entityType;
-    cout << ") Parameter Data Record for entity at DE " << sequenceNumber << "\n";
+    cerr << "[INFO] Entity(" << entityType;
+    cerr << ") Parameter Data Record for entity at DE " << sequenceNumber << "\n";
 #endif
 
     bool first = true;
@@ -1480,7 +1480,7 @@ bool IGES_ENTITY::readPD(std::ifstream &aFile, int &aSequenceVar)
         }
 
 #ifdef DEBUG
-        cout << "    " << rec.data << "\n";
+        cerr << "    " << rec.data << "\n";
 #endif
 
         if( rec.section_type != 'P' )
@@ -1571,7 +1571,7 @@ bool IGES_ENTITY::readPD(std::ifstream &aFile, int &aSequenceVar)
     }
 
 #ifdef DEBUG
-    cout << "-----\n";
+    cerr << "-----\n";
 #endif
 
     return true;

--- a/src/geom/mcad_helpers.cpp
+++ b/src/geom/mcad_helpers.cpp
@@ -107,28 +107,28 @@ bool CheckNormal( double& X, double &Y, double& Z )
 
 void print_transform( const MCAD_TRANSFORM* T )
 {
-    cout << setprecision( 3 );
-    cout << "R1: " << T->R.v[0][0] << ", " << T->R.v[0][1] << ", " << T->R.v[0][2] << ",  T.x = " << T->T.x << "\n";
-    cout << "R2: " << T->R.v[1][0] << ", " << T->R.v[1][1] << ", " << T->R.v[1][2] << ",  T.y = " << T->T.y << "\n";
-    cout << "R3: " << T->R.v[2][0] << ", " << T->R.v[2][1] << ", " << T->R.v[2][2] << ",  T.z = " << T->T.z << "\n";
+    cerr << setprecision( 3 );
+    cerr << "R1: " << T->R.v[0][0] << ", " << T->R.v[0][1] << ", " << T->R.v[0][2] << ",  T.x = " << T->T.x << "\n";
+    cerr << "R2: " << T->R.v[1][0] << ", " << T->R.v[1][1] << ", " << T->R.v[1][2] << ",  T.y = " << T->T.y << "\n";
+    cerr << "R3: " << T->R.v[2][0] << ", " << T->R.v[2][1] << ", " << T->R.v[2][2] << ",  T.z = " << T->T.z << "\n";
     return;
 }
 
 
 void print_matrix( const MCAD_MATRIX* m )
 {
-    cout << setprecision( 3 );
-    cout << "R1: " << m->v[0][0] << ", " << m->v[0][1] << ", " << m->v[0][2] << "\n";
-    cout << "R2: " << m->v[1][0] << ", " << m->v[1][1] << ", " << m->v[1][2] << "\n";
-    cout << "R3: " << m->v[2][0] << ", " << m->v[2][1] << ", " << m->v[2][2] << "\n";
+    cerr << setprecision( 3 );
+    cerr << "R1: " << m->v[0][0] << ", " << m->v[0][1] << ", " << m->v[0][2] << "\n";
+    cerr << "R2: " << m->v[1][0] << ", " << m->v[1][1] << ", " << m->v[1][2] << "\n";
+    cerr << "R3: " << m->v[2][0] << ", " << m->v[2][1] << ", " << m->v[2][2] << "\n";
     return;
 }
 
 
 void print_vec( const MCAD_POINT* p )
 {
-    cout << setprecision( 3 );
-    cout << "V: " << p->x << ", " << p->y << ", " << p->z << "\n";
+    cerr << setprecision( 3 );
+    cerr << "V: " << p->x << ", " << p->y << ", " << p->z << "\n";
     return;
 }
 

--- a/src/geom/mcad_outline.cpp
+++ b/src/geom/mcad_outline.cpp
@@ -45,50 +45,50 @@ using namespace std;
 
 void MCAD_OUTLINE::PrintPoint( MCAD_POINT p0 )
 {
-    cout << "(" << p0.x << ", " << p0.y << ")\n";
+    cerr << "(" << p0.x << ", " << p0.y << ")\n";
 }
 
 
 void MCAD_OUTLINE::PrintSeg( MCAD_SEGMENT* seg )
 {
-    cout << "      type: ";
+    cerr << "      type: ";
 
     switch( seg->GetSegType() )
     {
         case MCAD_SEGTYPE_NONE:
-            cout << "NONE\n";
+            cerr << "NONE\n";
             break;
 
         case MCAD_SEGTYPE_ARC:
-            cout << "ARC\n";
-            cout << "            c";
+            cerr << "ARC\n";
+            cerr << "            c";
             PrintPoint( seg->GetCenter() );
-            cout << "            s";
+            cerr << "            s";
             PrintPoint( seg->GetStart() );
-            cout << "            e";
+            cerr << "            e";
             PrintPoint( seg->GetEnd() );
-            cout << "            cw: " << seg->IsCW() << "\n";
-            cout << "            ang_start/ang_end: ";
-            cout << seg->GetStartAngle() << ", " << seg->GetEndAngle() << "\n";
+            cerr << "            cw: " << seg->IsCW() << "\n";
+            cerr << "            ang_start/ang_end: ";
+            cerr << seg->GetStartAngle() << ", " << seg->GetEndAngle() << "\n";
             break;
 
         case MCAD_SEGTYPE_CIRCLE:
-            cout << "CIRCLE\n";
-            cout << "            c";
+            cerr << "CIRCLE\n";
+            cerr << "            c";
             PrintPoint( seg->GetCenter() );
-            cout << "            r:" << seg->GetRadius();
+            cerr << "            r:" << seg->GetRadius();
             break;
 
         case MCAD_SEGTYPE_LINE:
-            cout << "LINE\n";
-            cout << "            s";
+            cerr << "LINE\n";
+            cerr << "            s";
             PrintPoint( seg->GetStart() );
-            cout << "            e";
+            cerr << "            e";
             PrintPoint( seg->GetEnd() );
             break;
 
         default:
-            cout << "INVALID\n";
+            cerr << "INVALID\n";
             break;
     }
 }
@@ -932,11 +932,11 @@ bool MCAD_OUTLINE::opOutline( MCAD_SEGMENT* aCircle, bool& error, bool opsub )
         ERRMSG << msg.str() << "\n";
         errors.push_back( msg.str() );
         error = true;
-        cout << "  c";
+        cerr << "  c";
         PrintPoint( p0 );
-        cout << "  s";
+        cerr << "  s";
         PrintPoint( pF[0] );
-        cout << "  e";
+        cerr << "  e";
         PrintPoint( pF[1] );
         delete sp;
         return false;
@@ -1044,9 +1044,9 @@ bool MCAD_OUTLINE::opOutline( MCAD_SEGMENT* aCircle, bool& error, bool opsub )
                 ERRMSG << msg.str() << "\n";
                 errors.push_back( msg.str() );
                 error = true;
-                cout << "Segment to be split:\n";
+                cerr << "Segment to be split:\n";
                 PrintSeg(*pSeg[i]);
-                cout << "Split point v";
+                cerr << "Split point v";
                 PrintPoint(pF[i]);
                 delete sp;
                 return false;

--- a/src/idf/idf2igs.cpp
+++ b/src/idf/idf2igs.cpp
@@ -102,7 +102,7 @@ int GetComponentColor( void );
 
 void PrintUsage( void )
 {
-    cout << "-\nUsage: idfigs input_file.emn\n";
+    cerr << "-\nUsage: idfigs input_file.emn\n";
     return;
 }
 
@@ -132,7 +132,7 @@ int main( int argc, char **argv )
 
     IDF3_BOARD pcb( IDF3::CAD_ELEC );
 
-    cout << "** Reading file: " << inputFilename << "\n";
+    cerr << "** Reading file: " << inputFilename << "\n";
 
     if( !pcb.ReadFile( inputFilename, true ) )
     {
@@ -166,7 +166,7 @@ int main( int argc, char **argv )
     string fname = mofname.GetFullPath();
     globs.basename = mofname.GetBaseName();
 
-    cout << "Output file: '" << fname << "'\n";
+    cerr << "Output file: '" << fname << "'\n";
 
     // STEP 1: Render the PCB alone
     MakeBoard( pcb, model );

--- a/src/iges/iges.cpp
+++ b/src/iges/iges.cpp
@@ -1757,7 +1757,7 @@ void IGES::Cull( bool vicious )
             && entities[iEnt]->GetEntityType() != ENT_SINGULAR_SUBFIGURE_INSTANCE ) )
         {
 #ifdef DEBUG
-            cout << " + [INFO] deleting Entity " << entities[iEnt]->GetEntityType() << "\n";
+            cerr << " + [INFO] deleting Entity " << entities[iEnt]->GetEntityType() << "\n";
 #endif
 
             ++nCulled;
@@ -1773,8 +1773,8 @@ void IGES::Cull( bool vicious )
     entities = tmpEnts;
 
 #ifdef DEBUG
-    cout << " + [INFO] Entities culled: " << nCulled << "\n";
-    cout << " + [INFO] Entities remaining: " << entities.size() << "\n";
+    cerr << " + [INFO] Entities culled: " << nCulled << "\n";
+    cerr << " + [INFO] Entities remaining: " << entities.size() << "\n";
 #endif
 
     return;

--- a/src/tests/test_merge.cpp
+++ b/src/tests/test_merge.cpp
@@ -294,7 +294,7 @@ bool merge( DLL_IGES& modelOut, const std::string fname, list<TPARAMS>*pos, vect
 
                 if( !pO )
                 {
-                    cout << "Could not instantiate a transform for '" << fname << "'\n";
+                    cerr << "Could not instantiate a transform for '" << fname << "'\n";
                     return false;
                 }
 
@@ -339,7 +339,7 @@ bool merge( DLL_IGES& modelOut, const std::string fname, list<TPARAMS>*pos, vect
                 if( pO )
                     delete pO;
 
-                cout << "Could not export model '" << fname << "'\n";
+                cerr << "Could not export model '" << fname << "'\n";
                 return false;
             }
         }

--- a/src/tests/test_outline.cpp
+++ b/src/tests/test_outline.cpp
@@ -57,7 +57,7 @@ int main()
     {
         if( test_arcs() )
         {
-            cout << "[FAIL]: test_arcs() encountered problems\n";
+            cerr << "[FAIL]: test_arcs() encountered problems\n";
             return -1;
         }
     }
@@ -66,7 +66,7 @@ int main()
     {
         if( test_lines() )
         {
-            cout << "[FAIL]: test_lines() encountered problems\n";
+            cerr << "[FAIL]: test_lines() encountered problems\n";
             return -1;
         }
     }
@@ -75,7 +75,7 @@ int main()
     {
         if( test_addr() )
         {
-            cout << "[FAIL]: test_addr() encountered problems\n";
+            cerr << "[FAIL]: test_addr() encountered problems\n";
             return -1;
         }
     }
@@ -86,7 +86,7 @@ int main()
         {
             if( test_otln( false, true ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems adding to Outline A\n";
+                cerr << "[FAIL]: test_otln() encountered problems adding to Outline A\n";
                 return -1;
             }
         }
@@ -95,7 +95,7 @@ int main()
         {
             if( test_otln( false, false ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems adding to Outline B\n";
+                cerr << "[FAIL]: test_otln() encountered problems adding to Outline B\n";
                 return -1;
             }
         }
@@ -104,7 +104,7 @@ int main()
         {
             if( test_otln( true, true ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems subtracting from Outline A\n";
+                cerr << "[FAIL]: test_otln() encountered problems subtracting from Outline A\n";
                 return -1;
             }
         }
@@ -113,14 +113,14 @@ int main()
         {
             if( test_otln( true, false ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems subtracting from Outline B\n";
+                cerr << "[FAIL]: test_otln() encountered problems subtracting from Outline B\n";
                 return -1;
             }
         }
 
     }
 
-    cout << "[OK]: All tests passed\n";
+    cerr << "[OK]: All tests passed\n";
     return 0;
 }
 
@@ -156,12 +156,12 @@ int test_arcs( void ) {
 
     if( !otln.AddSegment(seg1, error) )
     {
-        cout << "* [FAIL]: could not add segment to outline, error: " << error << "\n";
+        cerr << "* [FAIL]: could not add segment to outline, error: " << error << "\n";
         return -1;
     }
 
     if( seg1.IsValid() ) {
-        cout << "* [FAIL]: segment seg1 should not be valid\n";
+        cerr << "* [FAIL]: segment seg1 should not be valid\n";
         return -1;
     }
 
@@ -169,18 +169,18 @@ int test_arcs( void ) {
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
     if( !otln.SubOutline( seg2, error ) )
     {
-        cout << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
+        cerr << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
         return -1;
     }
 
     if( seg2.IsValid() ) {
-        cout << "* [FAIL]: segment seg2 should not be valid\n";
+        cerr << "* [FAIL]: segment seg2 should not be valid\n";
         return -1;
     }
 
@@ -198,7 +198,7 @@ int test_arcs( void ) {
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
 
@@ -214,7 +214,7 @@ int test_arcs( void ) {
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
 
@@ -230,7 +230,7 @@ int test_arcs( void ) {
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -249,7 +249,7 @@ int test_arcs( void ) {
 
         if( !otln.SubOutline( seg2, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -268,7 +268,7 @@ int test_arcs( void ) {
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -287,7 +287,7 @@ int test_arcs( void ) {
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -325,7 +325,7 @@ int test_arcs( void ) {
 
         if( !otln.SubOutline( s1, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout which intersects endpoints, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout which intersects endpoints, error: " << error << "\n";
             return -1;
         }
     }
@@ -344,7 +344,7 @@ int test_arcs( void ) {
 
         if( !otln.AddCutout( seg3, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -363,7 +363,7 @@ int test_arcs( void ) {
 
         if( !otln.SubOutline( seg2, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -382,14 +382,14 @@ int test_arcs( void ) {
 
         if( !otln.SubOutline( seg2, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -399,7 +399,7 @@ int test_arcs( void ) {
 
     if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, 1.5, -1.5 ) )
     {
-        cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
         return -1;
     }
 
@@ -438,7 +438,7 @@ int test_lines( void )
         || !otln.AddSegment( sides[2], error )
         || !otln.AddSegment( sides[3], error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -446,7 +446,7 @@ int test_lines( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -467,7 +467,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -482,7 +482,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -497,7 +497,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -512,7 +512,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -527,7 +527,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -542,7 +542,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -557,7 +557,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -572,7 +572,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
     }
@@ -589,13 +589,13 @@ int test_lines( void )
 
     if( !otln.AddCutout( hole, true, error ) )
     {
-        cout << "* [FAIL]: could not add a cutout\n";
+        cerr << "* [FAIL]: could not add a cutout\n";
         return -1;
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -605,7 +605,7 @@ int test_lines( void )
 
     if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, 0.8, -0.8 ) )
     {
-        cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
         return -1;
     }
 
@@ -657,7 +657,7 @@ int test_addr( void )
         || !otln.AddSegment( sides[2], error )
         || !otln.AddSegment( sides[3], error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -665,7 +665,7 @@ int test_addr( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -687,7 +687,7 @@ int test_addr( void )
 
         if( !otln.AddOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
@@ -709,7 +709,7 @@ int test_addr( void )
 
         if( !otln.AddOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
@@ -727,7 +727,7 @@ int test_addr( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
@@ -746,14 +746,14 @@ int test_addr( void )
 
         if( !otln.AddOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -763,7 +763,7 @@ int test_addr( void )
 
     if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, 0.8, -0.8 ) )
     {
-        cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
         return -1;
     }
 
@@ -801,7 +801,7 @@ int test_otln( bool subs, bool primeA )
         || !otlnB.AddSegment( sides[2], error )
         || !otlnB.AddSegment( sides[3], error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -809,7 +809,7 @@ int test_otln( bool subs, bool primeA )
 
     if( !otlnB.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -873,7 +873,7 @@ int test_otln( bool subs, bool primeA )
 
     if( !otln[0].IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -884,7 +884,7 @@ int test_otln( bool subs, bool primeA )
             // add outline B to A
             if( !otln[0].AddOutline( otlnB, error ) )
             {
-                cout << "* [FAIL]: could not add an outline\n";
+                cerr << "* [FAIL]: could not add an outline\n";
                 return -1;
             }
 
@@ -893,7 +893,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otln[0].AddOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not add outline " << i << "\n";
+                    cerr << "* [FAIL]: could not add outline " << i << "\n";
                     return -1;
                 }
             }
@@ -903,7 +903,7 @@ int test_otln( bool subs, bool primeA )
             // subtract outline B from A
             if( !otln[0].SubOutline( otlnB, error ) )
             {
-                cout << "* [FAIL]: could not subtract an outline\n";
+                cerr << "* [FAIL]: could not subtract an outline\n";
                 return -1;
             }
 
@@ -912,7 +912,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otln[0].SubOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not subtract outline " << i << "\n";
+                    cerr << "* [FAIL]: could not subtract outline " << i << "\n";
                     return -1;
                 }
             }
@@ -920,7 +920,7 @@ int test_otln( bool subs, bool primeA )
 
         if( !otln[0].IsContiguous( ret ) || !ret )
         {
-            cout << "* [FAIL]: outline was not contiguous\n";
+            cerr << "* [FAIL]: outline was not contiguous\n";
             return -1;
         }
 
@@ -930,7 +930,7 @@ int test_otln( bool subs, bool primeA )
 
         if( !otln[0].GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, 0.8, -0.8 ) )
         {
-            cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
             return -1;
         }
 
@@ -948,7 +948,7 @@ int test_otln( bool subs, bool primeA )
             // add outline A to B
             if( !otlnB.AddOutline( otln[0], error ) )
             {
-                cout << "* [FAIL]: could not add an outline\n";
+                cerr << "* [FAIL]: could not add an outline\n";
                 return -1;
             }
 
@@ -957,7 +957,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otlnB.AddOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not add outline " << i << "\n";
+                    cerr << "* [FAIL]: could not add outline " << i << "\n";
                     return -1;
                 }
             }
@@ -968,7 +968,7 @@ int test_otln( bool subs, bool primeA )
             // subtract outline A from B
             if( !otlnB.SubOutline( otln[0], error ) )
             {
-                cout << "* [FAIL]: could not subtract an outline\n";
+                cerr << "* [FAIL]: could not subtract an outline\n";
                 return -1;
             }
 
@@ -977,7 +977,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otlnB.SubOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not subtract outline " << i << "\n";
+                    cerr << "* [FAIL]: could not subtract outline " << i << "\n";
                     return -1;
                 }
             }
@@ -986,7 +986,7 @@ int test_otln( bool subs, bool primeA )
 
         if( !otlnB.IsContiguous( ret ) || !ret )
         {
-            cout << "* [FAIL]: outline was not contiguous\n";
+            cerr << "* [FAIL]: outline was not contiguous\n";
             return -1;
         }
 
@@ -996,7 +996,7 @@ int test_otln( bool subs, bool primeA )
 
         if( !otlnB.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, 0.8, -0.8 ) )
         {
-            cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
             return -1;
         }
 

--- a/src/tests/test_plane.cpp
+++ b/src/tests/test_plane.cpp
@@ -66,7 +66,7 @@ int main()
     {
         if( test_cc0() )
         {
-            cout << "[FAIL]: test_cc0() encountered problems\n";
+            cerr << "[FAIL]: test_cc0() encountered problems\n";
             return -1;
         }
     }
@@ -75,7 +75,7 @@ int main()
     {
         if( test_cc1() )
         {
-            cout << "[FAIL]: test_cc1() encountered problems\n";
+            cerr << "[FAIL]: test_cc1() encountered problems\n";
             return -1;
         }
     }
@@ -84,7 +84,7 @@ int main()
     {
         if( test_arcs() )
         {
-            cout << "[FAIL]: test_arcs() encountered problems\n";
+            cerr << "[FAIL]: test_arcs() encountered problems\n";
             return -1;
         }
     }
@@ -93,7 +93,7 @@ int main()
     {
         if( test_lines() )
         {
-            cout << "[FAIL]: test_lines() encountered problems\n";
+            cerr << "[FAIL]: test_lines() encountered problems\n";
             return -1;
         }
     }
@@ -102,7 +102,7 @@ int main()
     {
         if( test_addr() )
         {
-            cout << "[FAIL]: test_addr() encountered problems\n";
+            cerr << "[FAIL]: test_addr() encountered problems\n";
             return -1;
         }
     }
@@ -113,7 +113,7 @@ int main()
         {
             if( test_otln( false, true ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems adding to Outline A\n";
+                cerr << "[FAIL]: test_otln() encountered problems adding to Outline A\n";
                 return -1;
             }
         }
@@ -122,7 +122,7 @@ int main()
         {
             if( test_otln( false, false ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems adding to Outline B\n";
+                cerr << "[FAIL]: test_otln() encountered problems adding to Outline B\n";
                 return -1;
             }
         }
@@ -131,7 +131,7 @@ int main()
         {
             if( test_otln( true, true ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems subtracting from Outline A\n";
+                cerr << "[FAIL]: test_otln() encountered problems subtracting from Outline A\n";
                 return -1;
             }
         }
@@ -140,14 +140,14 @@ int main()
         {
             if( test_otln( true, false ) )
             {
-                cout << "[FAIL]: test_otln() encountered problems subtracting from Outline B\n";
+                cerr << "[FAIL]: test_otln() encountered problems subtracting from Outline B\n";
                 return -1;
             }
         }
 
     }
 
-    cout << "[OK]: All tests passed\n";
+    cerr << "[OK]: All tests passed\n";
     return 0;
 }
 
@@ -184,7 +184,7 @@ int test_arcs( void )
 
     if( !otln.AddSegment( seg1, error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -192,13 +192,13 @@ int test_arcs( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
     if( !otln.SubOutline( seg2, error ) )
     {
-        cout << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
+        cerr << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
         return -1;
     }
 
@@ -216,7 +216,7 @@ int test_arcs( void )
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
 
@@ -232,7 +232,7 @@ int test_arcs( void )
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
 
@@ -248,7 +248,7 @@ int test_arcs( void )
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -267,7 +267,7 @@ int test_arcs( void )
 
         if( !otln.SubOutline( seg2, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -286,7 +286,7 @@ int test_arcs( void )
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -305,7 +305,7 @@ int test_arcs( void )
 
         if( !otln.AddCutout( seg2, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -343,7 +343,7 @@ int test_arcs( void )
 
         if( !otln.SubOutline( s1, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout which intersects endpoints, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout which intersects endpoints, error: " << error << "\n";
             return -1;
         }
 
@@ -363,7 +363,7 @@ int test_arcs( void )
 
         if( !otln.AddCutout( seg3, true, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -382,7 +382,7 @@ int test_arcs( void )
 
         if( !otln.SubOutline( seg2, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -401,7 +401,7 @@ int test_arcs( void )
 
         if( !otln.SubOutline( seg2, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+            cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
             return -1;
         }
     }
@@ -418,13 +418,13 @@ int test_arcs( void )
 
     if( !otln.AddCutout( seg2, true, error ) )
     {
-        cout << "* [FAIL]: could not add a cutout, error: " << error << "\n";
+        cerr << "* [FAIL]: could not add a cutout, error: " << error << "\n";
         return -1;
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -436,7 +436,7 @@ int test_arcs( void )
     {
         if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
         {
-            cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
             return -1;
         }
 
@@ -448,7 +448,7 @@ int test_arcs( void )
     if( !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
         || !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
     {
-        cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
         return -1;
     }
 
@@ -486,7 +486,7 @@ int test_lines( void )
         || !otln.AddSegment( sides[2], error )
         || !otln.AddSegment( sides[3], error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -494,7 +494,7 @@ int test_lines( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -515,7 +515,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -530,7 +530,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -545,7 +545,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -560,7 +560,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -575,7 +575,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -590,7 +590,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -605,7 +605,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
 
@@ -620,7 +620,7 @@ int test_lines( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add a cutout\n";
+            cerr << "* [FAIL]: could not add a cutout\n";
             return -1;
         }
     }
@@ -637,13 +637,13 @@ int test_lines( void )
 
     if( !otln.AddCutout( hole, true, error ) )
     {
-        cout << "* [FAIL]: could not add a cutout\n";
+        cerr << "* [FAIL]: could not add a cutout\n";
         return -1;
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -653,14 +653,14 @@ int test_lines( void )
 
     if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
     {
-        cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
         return -1;
     }
 
     if( !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
         || !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
     {
-        cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
         return -1;
     }
 
@@ -712,7 +712,7 @@ int test_addr( void )
         || !otln.AddSegment( sides[2], error )
         || !otln.AddSegment( sides[3], error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -720,7 +720,7 @@ int test_addr( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -743,7 +743,7 @@ int test_addr( void )
 
         if( !otln.AddOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
@@ -766,7 +766,7 @@ int test_addr( void )
 
         if( !otln.AddOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
@@ -784,7 +784,7 @@ int test_addr( void )
 
         if( !otln.SubOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
@@ -803,14 +803,14 @@ int test_addr( void )
 
         if( !otln.AddOutline( circ, error ) )
         {
-            cout << "* [FAIL]: could not add an outline\n";
+            cerr << "* [FAIL]: could not add an outline\n";
             return -1;
         }
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -820,14 +820,14 @@ int test_addr( void )
 
     if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
     {
-        cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
         return -1;
     }
 
     if( !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
         || !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
     {
-        cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
         return -1;
     }
 
@@ -865,7 +865,7 @@ int test_otln( bool subs, bool primeA )
         || !otlnB.AddSegment( sides[2], error )
         || !otlnB.AddSegment( sides[3], error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -873,7 +873,7 @@ int test_otln( bool subs, bool primeA )
 
     if( !otlnB.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -937,7 +937,7 @@ int test_otln( bool subs, bool primeA )
 
     if( !otln[0].IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
@@ -948,7 +948,7 @@ int test_otln( bool subs, bool primeA )
             // add outline B to A
             if( !otln[0].AddOutline( otlnB, error ) )
             {
-                cout << "* [FAIL]: could not add an outline\n";
+                cerr << "* [FAIL]: could not add an outline\n";
                 return -1;
             }
 
@@ -957,7 +957,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otln[0].AddOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not add outline " << i << "\n";
+                    cerr << "* [FAIL]: could not add outline " << i << "\n";
                     return -1;
                 }
             }
@@ -967,7 +967,7 @@ int test_otln( bool subs, bool primeA )
             // subtract outline B from A
             if( !otln[0].SubOutline( otlnB, error ) )
             {
-                cout << "* [FAIL]: could not subtract an outline\n";
+                cerr << "* [FAIL]: could not subtract an outline\n";
                 return -1;
             }
 
@@ -976,7 +976,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otln[0].SubOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not subtract outline " << i << "\n";
+                    cerr << "* [FAIL]: could not subtract outline " << i << "\n";
                     return -1;
                 }
             }
@@ -984,7 +984,7 @@ int test_otln( bool subs, bool primeA )
 
         if( !otln[0].IsContiguous( ret ) || !ret )
         {
-            cout << "* [FAIL]: outline was not contiguous\n";
+            cerr << "* [FAIL]: outline was not contiguous\n";
             return -1;
         }
 
@@ -994,14 +994,14 @@ int test_otln( bool subs, bool primeA )
 
         if( !otln[0].GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
         {
-            cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
             return -1;
         }
 
         if( !otln[0].GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
             || !otln[0].GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
         {
-            cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
             return -1;
         }
 
@@ -1019,7 +1019,7 @@ int test_otln( bool subs, bool primeA )
             // add outline A to B
             if( !otlnB.AddOutline( otln[0], error ) )
             {
-                cout << "* [FAIL]: could not add an outline\n";
+                cerr << "* [FAIL]: could not add an outline\n";
                 return -1;
             }
 
@@ -1028,7 +1028,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otlnB.AddOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not add outline " << i << "\n";
+                    cerr << "* [FAIL]: could not add outline " << i << "\n";
                     return -1;
                 }
             }
@@ -1039,7 +1039,7 @@ int test_otln( bool subs, bool primeA )
             // subtract outline A from B
             if( !otlnB.SubOutline( otln[0], error ) )
             {
-                cout << "* [FAIL]: could not subtract an outline\n";
+                cerr << "* [FAIL]: could not subtract an outline\n";
                 return -1;
             }
 
@@ -1048,7 +1048,7 @@ int test_otln( bool subs, bool primeA )
             {
                 if( !otlnB.SubOutline( otln[i], error ) )
                 {
-                    cout << "* [FAIL]: could not subtract outline " << i << "\n";
+                    cerr << "* [FAIL]: could not subtract outline " << i << "\n";
                     return -1;
                 }
             }
@@ -1057,7 +1057,7 @@ int test_otln( bool subs, bool primeA )
 
         if( !otlnB.IsContiguous( ret ) || !ret )
         {
-            cout << "* [FAIL]: outline was not contiguous\n";
+            cerr << "* [FAIL]: outline was not contiguous\n";
             return -1;
         }
 
@@ -1067,14 +1067,14 @@ int test_otln( bool subs, bool primeA )
 
         if( !otlnB.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
         {
-            cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
             return -1;
         }
 
         if( !otlnB.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
             || !otlnB.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
         {
-            cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
             return -1;
         }
 
@@ -1124,7 +1124,7 @@ int test_cc0( void )
 
     if( !otln.AddSegment( seg1, error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -1132,19 +1132,19 @@ int test_cc0( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
     if( !otln.AddCutout( otlnB, false, error ) )
     {
-        cout << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
+        cerr << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
         return -1;
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -1154,14 +1154,14 @@ int test_cc0( void )
 
     if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
     {
-        cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
         return -1;
     }
 
     if( !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
         || !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
     {
-        cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
         return -1;
     }
 
@@ -1205,7 +1205,7 @@ int test_cc1( void )
 
     if( !otln.AddSegment( seg1, error ) )
     {
-        cout << "* [FAIL]: could not add segment to outline\n";
+        cerr << "* [FAIL]: could not add segment to outline\n";
         return -1;
     }
 
@@ -1213,19 +1213,19 @@ int test_cc1( void )
 
     if( !otln.IsClosed( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline is not closed\n";
+        cerr << "* [FAIL]: outline is not closed\n";
         return -1;
     }
 
     if( !otln.AddCutout( otlnB, true, error ) )
     {
-        cout << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
+        cerr << "* [FAIL]: could not subtract an outline, error: " << error << "\n";
         return -1;
     }
 
     if( !otln.IsContiguous( ret ) || !ret )
     {
-        cout << "* [FAIL]: outline was not contiguous\n";
+        cerr << "* [FAIL]: outline was not contiguous\n";
         return -1;
     }
 
@@ -1237,7 +1237,7 @@ int test_cc1( void )
     {
         if( !otln.GetVerticalSurface( model.GetRawPtr(), error, res, nSurfs, BTOP, BBOT ) )
         {
-            cout << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
+            cerr << "* [FAIL]: could not create vertical structures, error: " << error << "\n";
             return -1;
         }
     }
@@ -1245,7 +1245,7 @@ int test_cc1( void )
     if( !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BTOP, false )
         || !otln.GetTrimmedPlane( model.GetRawPtr(), error, res, nSurfs, BBOT, true ) )
     {
-        cout << "* [FAIL]: could not create planar structures, error: " << error << "\n";
+        cerr << "* [FAIL]: could not create planar structures, error: " << error << "\n";
         return -1;
     }
 

--- a/src/tests/test_read.cpp
+++ b/src/tests/test_read.cpp
@@ -42,8 +42,8 @@ using namespace std;
 
 void print_vec( const MCAD_POINT p )
 {
-    cout << setprecision( 3 );
-    cout << "V: " << p.x << ", " << p.y << ", " << p.z << "\n";
+    cerr << setprecision( 3 );
+    cerr << "V: " << p.x << ", " << p.y << ", " << p.z << "\n";
     return;
 }
 
@@ -51,7 +51,7 @@ int main( int argc, char **argv )
 {
     if( argc != 2 )
     {
-        cout << "*** Usage: readtest modelname\n";
+        cerr << "*** Usage: readtest modelname\n";
         return -1;
     }
 
@@ -63,7 +63,7 @@ int main( int argc, char **argv )
     }
     else
     {
-        cout << "[OK]: things are looking good\n";
+        cerr << "[OK]: things are looking good\n";
     }
 
     model.Write( ONAME, true );

--- a/src/tests/test_segs.cpp
+++ b/src/tests/test_segs.cpp
@@ -41,43 +41,43 @@ void print_flag( MCAD_INTERSECT_FLAG flag )
     switch( flag )
     {
         case MCAD_IFLAG_NONE:
-            cout << "[flag: none]";
+            cerr << "[flag: none]";
             break;
 
         case MCAD_IFLAG_ENDPOINT:
-            cout << "[flag: endpoint]";
+            cerr << "[flag: endpoint]";
             break;
 
         case MCAD_IFLAG_TANGENT:
-            cout << "[flag: tangent]";
+            cerr << "[flag: tangent]";
             break;
 
         case MCAD_IFLAG_EDGE:
-            cout << "[flag: edge]";
+            cerr << "[flag: edge]";
             break;
 
         case MCAD_IFLAG_INSIDE:
-            cout << "[flag: inside]";
+            cerr << "[flag: inside]";
             break;
 
         case MCAD_IFLAG_ENCIRCLES:
-            cout << "[flag: encircles]";
+            cerr << "[flag: encircles]";
             break;
 
         case MCAD_IFLAG_OUTSIDE:
-            cout << "[flag: outside]";
+            cerr << "[flag: outside]";
             break;
 
         case MCAD_IFLAG_IDENT:
-            cout << "[flag: identical]";
+            cerr << "[flag: identical]";
             break;
 
         case MCAD_IFLAG_MULTIEDGE:
-            cout << "[flag: multiedge]";
+            cerr << "[flag: multiedge]";
             break;
 
         default:
-            cout << "[unknown flag value: " << flag << "]";
+            cerr << "[unknown flag value: " << flag << "]";
             break;
     }
 
@@ -96,9 +96,9 @@ void testArcs( int& nTests, int& nFails );
 void checkFlags( MCAD_INTERSECT_FLAG f1, MCAD_INTERSECT_FLAG f2 )
 {
     if( f1 != f2 )
-        cout << "  [FAIL]: ";
+        cerr << "  [FAIL]: ";
     else
-        cout << "  [OK]: ";
+        cerr << "  [OK]: ";
 }
 
 int main()
@@ -111,7 +111,7 @@ int main()
     testArcSeg( nTests, nFails );
     testArcs( nTests, nFails );
 
-    cout << "\n** SUMMARY: " << nFails << " failures in " << nTests << " tests\n\n";
+    cerr << "\n** SUMMARY: " << nFails << " failures in " << nTests << " tests\n\n";
 
     return 0;
 }
@@ -124,7 +124,7 @@ void testCircles( int& nTests, int& nFails )
     MCAD_POINT c1[3];   // parameters for Circle 1
     MCAD_POINT c2[3];   // parameters for Circle 2
 
-    cout << "* Test: tangent circles\n";
+    cerr << "* Test: tangent circles\n";
     ++nTests;
 
     // radius: 1, c(0,0)
@@ -154,13 +154,13 @@ void testCircles( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2.GetRawPtr(), iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_TANGENT );
-        cout << "[expected failure: tangent] ";
+        cerr << "[expected failure: tangent] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
-        cout << "  [FAIL]: expected failure with tangent flag\n";
+        cerr << "  [FAIL]: expected failure with tangent flag\n";
         ++nFails;
 
         delete [] iList;
@@ -168,7 +168,7 @@ void testCircles( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: C1 encircled by C2\n";
+    cerr << "* Test: C1 encircled by C2\n";
     ++nTests;
 
     // radius: 0.5, c(0.5,0)
@@ -184,13 +184,13 @@ void testCircles( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_ENCIRCLES );
-        cout << "[expected failure: encircles] ";
+        cerr << "[expected failure: encircles] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
-        cout << "  [FAIL]: expected failure with 'encircles'\n";
+        cerr << "  [FAIL]: expected failure with 'encircles'\n";
         ++nFails;
 
         delete [] iList;
@@ -198,7 +198,7 @@ void testCircles( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: C2 inside C1\n";
+    cerr << "* Test: C2 inside C1\n";
     ++nTests;
 
     // radius: 1.5, c(0,0)
@@ -214,13 +214,13 @@ void testCircles( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_INSIDE );
-        cout << "[expected failure: inside] ";
+        cerr << "[expected failure: inside] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
-        cout << "  [FAIL]: expected failure with 'inside'\n";
+        cerr << "  [FAIL]: expected failure with 'inside'\n";
         ++nFails;
 
         delete [] iList;
@@ -228,7 +228,7 @@ void testCircles( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: no intersection\n";
+    cerr << "* Test: no intersection\n";
     ++nTests;
 
     // radius: 1, c(3,0)
@@ -244,13 +244,13 @@ void testCircles( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_NONE );
-        cout << "[expected failure: none] ";
+        cerr << "[expected failure: none] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
-        cout << "  [FAIL]: expected failure with 'none' (no intersection)\n";
+        cerr << "  [FAIL]: expected failure with 'none' (no intersection)\n";
         ++nFails;
 
         delete [] iList;
@@ -258,7 +258,7 @@ void testCircles( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: intersect at (0, 1), (0, -1)\n";
+    cerr << "* Test: intersect at (0, 1), (0, -1)\n";
     ++nTests;
 
     // radius: 3, c(sqrt(8),0)
@@ -274,16 +274,16 @@ void testCircles( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success --";
+        cerr << "  [FAIL]: expected success --";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_NONE );
-        cout << "found intersections at:\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "found intersections at:\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
@@ -303,7 +303,7 @@ void testCircleSeg(  int& nTests, int& nFails )
     MCAD_POINT c1[3];   // parameters for Circle 1
     MCAD_POINT l1[2];   // parameters for Line 1
 
-    cout << "* Test: tangent to circle (C1, L1)\n";
+    cerr << "* Test: tangent to circle (C1, L1)\n";
     ++nTests;
 
     // radius: 95.6, c(0,0)
@@ -331,25 +331,25 @@ void testCircleSeg(  int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success -- ";
+        cerr << "  [FAIL]: expected success -- ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected single point, got " << nIntersects << " ";
+            cerr << "  [FAIL]: expected single point, got " << nIntersects << " ";
             print_flag( flag );
-            cout << "\n";
+            cerr << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_TANGENT );
-            cout << " expected single endpoint (67.5994, 67.5994) with tangent flag ";
+            cerr << " expected single endpoint (67.5994, 67.5994) with tangent flag ";
             print_flag( flag );
-            cout << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -357,7 +357,7 @@ void testCircleSeg(  int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: tangent to circle (L1, C1)\n";
+    cerr << "* Test: tangent to circle (L1, C1)\n";
     ++nTests;
 
     l1[0].x -= 5.0;
@@ -367,25 +367,25 @@ void testCircleSeg(  int& nTests, int& nFails )
     if( !seg2.GetIntersections( seg1, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success -- ";
+        cerr << "  [FAIL]: expected success -- ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected single point, got " << nIntersects << " ";
+            cerr << "  [FAIL]: expected single point, got " << nIntersects << " ";
             print_flag( flag );
-            cout << "\n";
+            cerr << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_TANGENT );
-            cout << " expected single endpoint (67.5994, 67.5994) with tangent flag ";
+            cerr << " expected single endpoint (67.5994, 67.5994) with tangent flag ";
             print_flag( flag );
-            cout << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -393,7 +393,7 @@ void testCircleSeg(  int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: 1 point on circle\n";
+    cerr << "* Test: 1 point on circle\n";
     ++nTests;
 
     l1[0].x += 5.0;
@@ -405,23 +405,23 @@ void testCircleSeg(  int& nTests, int& nFails )
     if( !seg2.GetIntersections( seg1, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success -- ";
+        cerr << "  [FAIL]: expected success -- ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected single point, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected single point, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << " expected single endpoint (67.5994, 67.5994) ";
+            cerr << " expected single endpoint (67.5994, 67.5994) ";
             print_flag( flag );
-            cout << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -429,7 +429,7 @@ void testCircleSeg(  int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: 2 points on circle\n";
+    cerr << "* Test: 2 points on circle\n";
     ++nTests;
 
     l1[0].x = -l1[1].x;
@@ -439,23 +439,23 @@ void testCircleSeg(  int& nTests, int& nFails )
     if( !seg2.GetIntersections( seg1, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success -- ";
+        cerr << "  [FAIL]: expected success -- ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         if( nIntersects != 2 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_NONE );
-            cout << "expected 2 points (67.5994, 67.5994), (-67.5994, -67.5994)\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-            cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+            cerr << "expected 2 points (67.5994, 67.5994), (-67.5994, -67.5994)\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
         }
 
         delete [] iList;
@@ -476,7 +476,7 @@ void testArcSeg( int& nTests, int& nFails )
     MCAD_POINT c1[3];   // parameters for Arc 1
     MCAD_POINT l1[2];   // parameters for Line 1
 
-    cout << "* Test: vertical tangent to arc (A1, L1)\n";
+    cerr << "* Test: vertical tangent to arc (A1, L1)\n";
     ++nTests;
 
     // radius: 1, c(0,0)
@@ -504,25 +504,25 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success -- ";
+        cerr << "  [FAIL]: expected success -- ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected single point, got " << nIntersects << " ";
+            cerr << "  [FAIL]: expected single point, got " << nIntersects << " ";
             print_flag( flag );
-            cout << "\n";
+            cerr << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_TANGENT );
-            cout << " expected single point (67.5994, 67.5994) with tangent flag ";
+            cerr << " expected single point (67.5994, 67.5994) with tangent flag ";
             print_flag( flag );
-            cout << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -530,7 +530,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: horizontal tangent to arc (A1, L1)\n";
+    cerr << "* Test: horizontal tangent to arc (A1, L1)\n";
     ++nTests;
 
     // horizontal tangent:
@@ -543,25 +543,25 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success -- ";
+        cerr << "  [FAIL]: expected success -- ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected single point, got " << nIntersects << " ";
+            cerr << "  [FAIL]: expected single point, got " << nIntersects << " ";
             print_flag( flag );
-            cout << "\n";
+            cerr << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_TANGENT );
-            cout << " expected single point (67.5994, 67.5994) with tangent flag ";
+            cerr << " expected single point (67.5994, 67.5994) with tangent flag ";
             print_flag( flag );
-            cout << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -569,7 +569,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: tangent not on arc (A1, L1)\n";
+    cerr << "* Test: tangent not on arc (A1, L1)\n";
     ++nTests;
 
     l1[0].x = -1.0;
@@ -581,21 +581,21 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_NONE );
-        cout << "[expected failure: none] ";
+        cerr << "[expected failure: none] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         ++nFails;
-        cout << "  [FAIL]: expected failure flag 'none'\n";
+        cerr << "  [FAIL]: expected failure flag 'none'\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: endpoint arc (A1, L1), single point\n";
+    cerr << "* Test: endpoint arc (A1, L1), single point\n";
     ++nTests;
 
     l1[0].x = 0.0;
@@ -607,22 +607,22 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with endpoint flag\n";
+        cerr << "  [FAIL]: expected success with endpoint flag\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 1 point, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 1 point, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -630,7 +630,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: endpoint arc (A1, L1), 2 points\n";
+    cerr << "* Test: endpoint arc (A1, L1), 2 points\n";
     ++nTests;
 
     l1[0].x = 0.0;
@@ -642,23 +642,23 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with endpoint flag\n";
+        cerr << "  [FAIL]: expected success with endpoint flag\n";
     }
     else
     {
         if( nIntersects != 2 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-            cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
         }
 
         delete [] iList;
@@ -666,7 +666,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: endpoint arc (A1, L1), 2 points (one is not on an arc endpoint)\n";
+    cerr << "* Test: endpoint arc (A1, L1), 2 points (one is not on an arc endpoint)\n";
     ++nTests;
 
     l1[0].x = 0.0;
@@ -678,23 +678,23 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with endpoint flag\n";
+        cerr << "  [FAIL]: expected success with endpoint flag\n";
     }
     else
     {
         if( nIntersects != 2 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-            cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
         }
 
         delete [] iList;
@@ -702,7 +702,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: segment intersects arc at 2 endpoints of arc (but not endpoints of segment)\n";
+    cerr << "* Test: segment intersects arc at 2 endpoints of arc (but not endpoints of segment)\n";
     ++nTests;
 
     l1[0].x = 0.0;
@@ -714,23 +714,23 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with endpoint flag\n";
+        cerr << "  [FAIL]: expected success with endpoint flag\n";
     }
     else
     {
         if( nIntersects != 2 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-            cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
         }
 
         delete [] iList;
@@ -738,7 +738,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: segment intersects arc at 1 endpoint of arc (but not endpoints of segment)\n";
+    cerr << "* Test: segment intersects arc at 1 endpoint of arc (but not endpoints of segment)\n";
     ++nTests;
 
     l1[0].x = .0;
@@ -749,7 +749,7 @@ void testArcSeg( int& nTests, int& nFails )
 
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
-        cout << "  [FAIL]: expected success with endpoint flag\n";
+        cerr << "  [FAIL]: expected success with endpoint flag\n";
         ++nFails;
     }
     else
@@ -757,15 +757,15 @@ void testArcSeg( int& nTests, int& nFails )
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 1 point, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 1 point, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -773,7 +773,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: segment intersects arc at 2 endpoints of segment (but not endpoints of arc)\n";
+    cerr << "* Test: segment intersects arc at 2 endpoints of segment (but not endpoints of arc)\n";
     ++nTests;
 
     l1[0].x = cos( M_PI * 0.25 );
@@ -785,23 +785,23 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with endpoint flag\n";
+        cerr << "  [FAIL]: expected success with endpoint flag\n";
     }
     else
     {
         if( nIntersects != 2 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-            cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
         }
 
         delete [] iList;
@@ -809,7 +809,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: segment intersects arc at 2 points; none are endpoints\n";
+    cerr << "* Test: segment intersects arc at 2 points; none are endpoints\n";
     ++nTests;
 
     l1[0].y = -1.0;
@@ -819,23 +819,23 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with flag 'none'\n";
+        cerr << "  [FAIL]: expected success with flag 'none'\n";
     }
     else
     {
         if( nIntersects != 2 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 2 points, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_NONE );
-            cout << "[expected flag: none] ";
+            cerr << "[expected flag: none] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-            cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
         }
 
         delete [] iList;
@@ -843,7 +843,7 @@ void testArcSeg( int& nTests, int& nFails )
         nIntersects = 0;
     }
 
-    cout << "* Test: segment intersects arc at 1 endpoint of the segment\n";
+    cerr << "* Test: segment intersects arc at 1 endpoint of the segment\n";
     ++nTests;
 
     l1[0].y = 0.0;
@@ -853,22 +853,22 @@ void testArcSeg( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: expected success with flag 'endpoint'\n";
+        cerr << "  [FAIL]: expected success with flag 'endpoint'\n";
     }
     else
     {
         if( nIntersects != 1 )
         {
             ++nFails;
-            cout << "  [FAIL]: expected 1 point, got " << nIntersects << "\n";
+            cerr << "  [FAIL]: expected 1 point, got " << nIntersects << "\n";
         }
         else
         {
             checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-            cout << "[expected flag: endpoint] ";
+            cerr << "[expected flag: endpoint] ";
             print_flag( flag );
-            cout << "\n";
-            cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+            cerr << "\n";
+            cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
         }
 
         delete [] iList;
@@ -889,7 +889,7 @@ void testArcs( int& nTests, int& nFails )
     MCAD_POINT c1[3];   // parameters for Arc 1
     MCAD_POINT c2[3];   // parameters for Arc 2
 
-    cout << "* Test: tangent intersecting arcs\n";
+    cerr << "* Test: tangent intersecting arcs\n";
     ++nTests;
 
     c1[0].x = 0.0;
@@ -917,21 +917,21 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_TANGENT );
-        cout << "[expected failure: tangent] ";
+        cerr << "[expected failure: tangent] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         ++nFails;
-        cout << "  [FAIL]: expected failure with tangent flag\n";
+        cerr << "  [FAIL]: expected failure with tangent flag\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: tangent non-intersecting arcs\n";
+    cerr << "* Test: tangent non-intersecting arcs\n";
     ++nTests;
 
     c2[0].x = 2.0;
@@ -947,21 +947,21 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         checkFlags( flag, MCAD_IFLAG_NONE );
-        cout << "[expected failure: none] ";
+        cerr << "[expected failure: none] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         ++nFails;
-        cout << "  [FAIL]: expected failure with flag 'none' (no intersection)\n";
+        cerr << "  [FAIL]: expected failure with flag 'none' (no intersection)\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: C1 == C2\n";
+    cerr << "* Test: C1 == C2\n";
     ++nTests;
 
     seg2.SetParams( c1[0], c1[1], c1[2], false );
@@ -969,25 +969,25 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: edge] ";
+        cerr << "  [FAIL]: [expected success with flag: edge] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_EDGE );
-        cout << "[expected flag: edge] ";
+        cerr << "[expected flag: edge] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: partially overlapping arcs\n";
+    cerr << "* Test: partially overlapping arcs\n";
     ++nTests;
 
     c1[0].x = 0.0;
@@ -1011,25 +1011,25 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: edge] ";
+        cerr << "  [FAIL]: [expected success with flag: edge] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_EDGE );
-        cout << "[expected flag: edge] ";
+        cerr << "[expected flag: edge] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: non-overlapping arcs with same radius and coincident edges, r1 = r2\n";
+    cerr << "* Test: non-overlapping arcs with same radius and coincident edges, r1 = r2\n";
     ++nTests;
 
     c1[0].x = 0.0;
@@ -1053,26 +1053,26 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: endpoint] ";
+        cerr << "  [FAIL]: [expected success with flag: endpoint] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_ENDPOINT );
-        cout << "[expected success with flag: endpoint] ";
+        cerr << "[expected success with flag: endpoint] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: non-overlapping arcs, first arc is outside second arc, r1 > r2\n";
-    cout << "  and second arc is inside first arc\n";
+    cerr << "* Test: non-overlapping arcs, first arc is outside second arc, r1 > r2\n";
+    cerr << "  and second arc is inside first arc\n";
     ++nTests;
 
     c1[0].x = 0.0;
@@ -1096,25 +1096,25 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: outside] ";
+        cerr << "  [FAIL]: [expected success with flag: outside] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_OUTSIDE );
-        cout << "[expected success with flag: outside] ";
+        cerr << "[expected success with flag: outside] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: non-overlapping arcs, first arc is inside second arc, r1 < r2\n";
+    cerr << "* Test: non-overlapping arcs, first arc is inside second arc, r1 < r2\n";
     ++nTests;
 
     seg1.SetParams( c2[0], c2[1], c2[2], false );
@@ -1124,25 +1124,25 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: inside] ";
+        cerr << "  [FAIL]: [expected success with flag: inside] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_INSIDE );
-        cout << "[expected success with flag: inside] ";
+        cerr << "[expected success with flag: inside] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[1].y << "\n";
-        cout << "  p2: " << iList[0].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[1].y << "\n";
+        cerr << "  p2: " << iList[0].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: non-overlapping arcs, first arc is outside second arc, r1 > r2\n";
+    cerr << "* Test: non-overlapping arcs, first arc is outside second arc, r1 > r2\n";
     ++nTests;
 
     c2[0].x = 3.0;
@@ -1159,25 +1159,25 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: outside] ";
+        cerr << "  [FAIL]: [expected success with flag: outside] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_OUTSIDE );
-        cout << "[expected success with flag: outside] ";
+        cerr << "[expected success with flag: outside] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
         nIntersects = 0;
     }
 
-    cout << "* Test: non-overlapping arcs, first arc is outside second arc, r1 < r2\n";
+    cerr << "* Test: non-overlapping arcs, first arc is outside second arc, r1 < r2\n";
     ++nTests;
 
     seg1.SetParams( c2[0], c2[1], c2[2], false );
@@ -1187,18 +1187,18 @@ void testArcs( int& nTests, int& nFails )
     if( !seg1.GetIntersections( seg2, iList, nIntersects, flag ) )
     {
         ++nFails;
-        cout << "  [FAIL]: [expected success with flag: outside] ";
+        cerr << "  [FAIL]: [expected success with flag: outside] ";
         print_flag( flag );
-        cout << "\n";
+        cerr << "\n";
     }
     else
     {
         checkFlags( flag, MCAD_IFLAG_OUTSIDE );
-        cout << "[expected success with flag: outside] ";
+        cerr << "[expected success with flag: outside] ";
         print_flag( flag );
-        cout << "\n";
-        cout << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
-        cout << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
+        cerr << "\n";
+        cerr << "  p1: " << iList[0].x << ", " << iList[0].y << "\n";
+        cerr << "  p2: " << iList[1].x << ", " << iList[1].y << "\n";
 
         delete [] iList;
         iList = NULL;
@@ -1207,8 +1207,8 @@ void testArcs( int& nTests, int& nFails )
 
     // XXX -
     // WARNING: TO BE IMPLEMENTED
-    cout << "* Test: multiple-overlap arcs\n";
-    cout << "  [FAIL]: TEST NOT IMPLEMENTED\n";
+    cerr << "* Test: multiple-overlap arcs\n";
+    cerr << "  [FAIL]: TEST NOT IMPLEMENTED\n";
     ++nTests;
     ++nFails;
 


### PR DESCRIPTION
stdout is reserved for application output, libraries writing to it mess up normal behaviour.

I replaced all std::cout references with std::cerr in this PR.
Even better would be to have a way to specify the desired std::ostream (defaulting to std::cerr).